### PR TITLE
feat: centralize configuration via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql+asyncpg://USER:PASSWORD@localhost/car2go
+JWT_SECRET_KEY=your_secret_key
+JWT_ALGORITHM=HS256
+CORS_ORIGINS=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Car2Go Backend
+
+## Configuration
+
+Create a `.env` file in the project root by copying `.env.example`:
+
+```bash
+cp .env.example .env
+```
+
+Then fill in the following variables:
+
+- `DATABASE_URL`: Database connection string.
+- `JWT_SECRET_KEY`: Secret key used to sign JWT tokens.
+- `JWT_ALGORITHM`: Algorithm used for JWT tokens.
+- `CORS_ORIGINS`: Comma-separated list of allowed origins for CORS.
+
+The application will load these settings automatically when it starts.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+from typing import List
+from pydantic import BaseSettings, validator
+
+class Settings(BaseSettings):
+    database_url: str
+    jwt_secret_key: str
+    jwt_algorithm: str = "HS256"
+    cors_origins: List[str] = ["*"]
+
+    @validator("cors_origins", pre=True)
+    def split_cors_origins(cls, v):
+        if isinstance(v, str):
+            return [origin.strip() for origin in v.split(",")]
+        return v
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()

--- a/database.py
+++ b/database.py
@@ -1,13 +1,13 @@
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+from config import settings
 
-DATABASE_URL = "postgresql+asyncpg://lindabenboudiaf@localhost/car2go"
 
-engine = create_async_engine(DATABASE_URL, echo=True)
+engine = create_async_engine(settings.database_url, echo=True)
 SessionLocal = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
 Base = declarative_base()
 
-# Ajout de get_db pour fournir une session de base de données aux routes
+
 async def get_db():
     async with SessionLocal() as session:
         yield session

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from sqlalchemy.exc import SQLAlchemyError
 from fastapi.middleware.cors import CORSMiddleware
+from config import settings
 
 app = FastAPI()
 
@@ -21,7 +22,7 @@ async def log_requests(request: Request, call_next):
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 from typing import Optional
 from jose import JWTError, jwt
+from config import settings
 
-SECRET_KEY = "secret"
-ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     to_encode = data.copy()
@@ -13,11 +13,12 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     else:
         expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
 
 def verify_token(token: str):
     try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
         return payload
     except JWTError:
         return None


### PR DESCRIPTION
## Summary
- load application settings from `.env` using Pydantic `BaseSettings`
- use configuration for database URL, JWT settings and CORS origins
- document required environment variables and add example `.env`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1b8ea9ca08329966b9d93c67d4caa